### PR TITLE
Database Lint Config Update

### DIFF
--- a/opg_pipeline_builder/database.py
+++ b/opg_pipeline_builder/database.py
@@ -777,7 +777,10 @@ class DatabaseTable:
                     else:
                         tbl_meta.update_column({"name": c, "type": cols_map[c]})
 
-                pq_args = {"metadata": tbl_meta.to_dict(), "expect_full_schema": False}
+                pq_args = {
+                    "metadata": tbl_meta.to_dict(),
+                    "parquet_expect_full_schema": False,
+                }
 
                 config["pandas-kwargs"] = {**pandas_kwargs, **pq_args}
 


### PR DESCRIPTION
Update lint config to use `parquet_expect_full_schema` instead of `expect_full_schema` following updates to arrow-pd-parser.