### PR TITLE
Derived tables fix

### DIFF
--- a/opg_pipeline_builder/transform_engines/athena.py
+++ b/opg_pipeline_builder/transform_engines/athena.py
@@ -527,7 +527,10 @@ class AthenaTransformEngine(BaseTransformEngine):
 
         existing_prts = set(
             self.utils.list_partitions(
-                table_name=table_name, stage="derived", extract_timestamp=True
+                table_name=table_name,
+                stage="derived",
+                extract_timestamp=True,
+                disable_environment=True,
             )
         )
 

--- a/opg_pipeline_builder/transform_engines/utils/utils.py
+++ b/opg_pipeline_builder/transform_engines/utils/utils.py
@@ -38,6 +38,7 @@ class TransformEngineUtils(BaseModel):
         modified_after: Optional[Union[datetime, None]] = None,
         modified_before: Optional[Union[datetime, None]] = None,
         additional_stages: Optional[Union[Dict[str, str], None]] = None,
+        disable_environment: Optional[bool] = False,
     ) -> List[str]:
         """Lists files in S3 for a given table
 
@@ -75,7 +76,7 @@ class TransformEngineUtils(BaseModel):
         if modified_after is None:
             modified_after = get_start_date()
 
-        if modified_before is None:
+        if modified_before is None and disable_environment is False:
             modified_before = get_end_date()
 
         table = self._db.table(table_name)


### PR DESCRIPTION
Updated  base engine`utils` and `run_derived` in `athena` engine to disable environment when `END_DATE` is set.