### PR TITLE
Pull secrets from environ vars for new airflow

### DIFF
--- a/src/opg_pipeline_builder/transform_engines/utils/utils.py
+++ b/src/opg_pipeline_builder/transform_engines/utils/utils.py
@@ -8,10 +8,9 @@ import awswrangler as wr
 from dataengineeringutils3.s3 import _add_slash
 from mojap_metadata import Metadata
 from pydantic import BaseModel
-from ssm_parameter_store import EC2ParameterStore
 
 from ...database import Database
-from ...utils.constants import aws_region, get_end_date, get_source_tbls, get_start_date
+from ...utils.constants import get_end_date, get_source_tbls, get_start_date
 from ...utils.utils import (
     extract_mojap_partition,
     extract_mojap_timestamp,
@@ -295,11 +294,10 @@ class TransformEngineUtils(BaseModel):
         return (input_path, output_path, tf_type)
 
     def get_secrets(self, secret_key: str) -> str:
-        """Return secret from parameter store
+        """Return secret from environment variable.
 
-        Returns the given secret from the EC2 parameter store
-        for the pipeline. Note, IAM_ROLE env variable needs to
-        be set for this method.
+        Looks up the value from the environment variables for the
+        given secret key.
 
         Params
         ------
@@ -309,16 +307,15 @@ class TransformEngineUtils(BaseModel):
         Return
         ------
         str
-            Secret value from parameter store.
+            Secret value from environment variable containing the secret.
         """
-        iam_role = os.environ["IAM_ROLE"]
-        store = EC2ParameterStore(region_name=aws_region)
+        secret = os.getenv(secret_key, None)
 
-        param_path = os.path.join("/alpha/airflow/", iam_role, "secrets", self._db.name)
+        if not secret:
+            err = f"No value found for secret: '{secret_key}'. The secret needs to be added to the DAG manifest file and AWS secret manager."
+            raise ValueError(err)
 
-        secrets = store.get_parameters_by_path(param_path)
-
-        return secrets[secret_key]
+        return secret
 
     @staticmethod
     def cleanup_partitions(base_data_path: str, partitions: List[str]):

--- a/tests/test_base_engine.py
+++ b/tests/test_base_engine.py
@@ -3,9 +3,7 @@ import time
 from datetime import timedelta
 from itertools import chain
 
-import boto3
 import pytest
-from moto import mock_aws
 
 from tests.conftest import dep_bucket, land_bucket, raw_hist_bucket, set_up_s3
 
@@ -508,21 +506,17 @@ class TestBaseEngineTransform:
         transform = self.get_transform()
         assert transform.utils.tf_args(table_name=table_name, stages=stages) == expected
 
-    @mock_aws
-    @pytest.mark.parametrize("secret_key, value", [("dummy", "hjshfkheu27837")])
-    def test_get_secrets(self, secret_key, value):
+    def test_get_secrets_valid(self) -> None:
+        os.environ["dummy"] = "fjg95ihi94wg"
         transform = self.get_transform()
-        db = transform.db
-        ssm_client = boto3.client("ssm")
-        _ = ssm_client.put_parameter(
-            Name=os.path.join(
-                "/alpha/airflow/",
-                os.environ["IAM_ROLE"],
-                "secrets",
-                db.name,
-                secret_key,
-            ),
-            Type="SecureString",
-            Value=value,
+        assert transform.utils.get_secrets("dummy") == "fjg95ihi94wg"
+
+    def test_get_secrets_invalid(self) -> None:
+        os.environ["valid"] = "fjg95ihi94wg"
+        transform = self.get_transform()
+        with pytest.raises(ValueError) as error:
+            transform.utils.get_secrets("invalid")
+        assert (
+            str(error.value)
+            == "No value found for secret: 'invalid'. The secret needs to be added to the DAG manifest file and AWS secret manager."  # pragma: allowlist secret
         )
-        assert transform.utils.get_secrets(secret_key) == value


### PR DESCRIPTION
In line with new airflow, which pipes secrets in as environment variables (https://user-guidance.analytical-platform.service.justice.gov.uk/services/airflow/index.html#workflow-secrets), updated logic to now pull the secret from the environment variables. Raises an exception if the secret key can not be found and directs user to add to the DAG and secret manager, as per airflow guidance.