### PR TITLE
fix: listing of table files now removes sirius schema prefixes if pre…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.12, <3.13"
 dependencies = [
     "aiobotocore>=3.7.0",
     "awswrangler>=3.11.0",
-    "boto3==1.42.90",
+    "boto3==1.43.0",
     "croniter>=6.0.0",
     "data-linter>=6.3.6",
     "dataengineeringutils3>=1.4.3",

--- a/src/opg_pipeline_builder/database.py
+++ b/src/opg_pipeline_builder/database.py
@@ -709,8 +709,7 @@ class DatabaseTable:
                 raise KeyError("Derived table should have inputs listed in config.")
 
             all_data_paths: dict[str, dict[str, str]] = {}
-            for db_name in input_data:
-                tables = input_data[db_name]
+            for db_name, tables in input_data.items():
                 table_names = list(tables.keys())
                 all_data_paths[db_name] = {}
 
@@ -730,7 +729,8 @@ class DatabaseTable:
                     table_freq = table.frequency()
 
                     all_data_paths[db_name][table_name] = {
-                        **{"path": data_paths, "frequency": table_freq},  # type: ignore
+                        "path": data_paths,
+                        "frequency": table_freq,
                         **data_formats,  # type: ignore
                     }
 
@@ -789,7 +789,7 @@ class DatabaseTable:
         config = {}
         if transform_type in ["default", "custom"]:
             table_lint_config = self._config
-            if "lint_options" not in table_lint_config.keys():
+            if "lint_options" not in table_lint_config:
                 raise KeyError(f"Lint options have not been specified for {self._name}")
 
             table_meta = self.table_meta_paths()
@@ -883,7 +883,7 @@ class DatabaseTable:
         return transform_args
 
     def get_table_metadata(
-        self, stage: str, updates: list[dict[str, str | bool] | None] = []
+        self, stage: str, updates: list[dict[str, str | bool] | None] | None = None
     ) -> Metadata:
         """Fetches MoJ Metadata for the table
 
@@ -897,7 +897,7 @@ class DatabaseTable:
         stage: str
             ETL stage for meta to retrieve.
 
-        updates: list[dict[str, str] | None]
+        updates: list[dict[str, str | bool] | None] | None
             Only required for updating meta. Expects a list
             of dictionary objects to pass to MoJ Metadata's
             update_column method.

--- a/src/opg_pipeline_builder/transform_engines/athena.py
+++ b/src/opg_pipeline_builder/transform_engines/athena.py
@@ -1,4 +1,6 @@
+import functools
 import logging
+import operator
 import os
 from typing import Any
 
@@ -44,10 +46,11 @@ class AthenaTransformEngine(BaseTransformEngine):
 
     def model_post_init(
         self,
-        __context: Any,
+        context: Any,
+        /,
     ) -> None:
         self.utils = AthenaTransformEngineUtils(db=self.db)
-        super().model_post_init(__context)
+        super().model_post_init(context)
 
         if self.transforms is None:
             transforms_type = (
@@ -246,15 +249,7 @@ class AthenaTransformEngine(BaseTransformEngine):
         self, table_name: str, input_stage: str
     ) -> str:
         input_stage_under = input_stage.replace("-", "_")
-        return "_".join(
-            [
-                "_temp",
-                self.db.name,
-                self.db.env,
-                table_name,
-                input_stage_under,
-            ]
-        )
+        return f"_temp_{self.db.name}_{self.db.env}_{table_name}_{input_stage_under}"
 
     def _prepare_input_metadata_for_load(
         self, table_name: str, input_stage: str
@@ -377,11 +372,9 @@ class AthenaTransformEngine(BaseTransformEngine):
 
         except Exception as e:
             _logger.info(
-                (
-                    "Failed to write data to curated.\n"
-                    f"Error: {e}\n"
-                    "Deleting any half-written files.\n"
-                )
+                "Failed to write data to curated.\n"
+                f"Error: {e}\n"
+                "Deleting any half-written files.\n"
             )
 
             self.utils.cleanup_partitions(  # type: ignore
@@ -497,7 +490,8 @@ class AthenaTransformEngine(BaseTransformEngine):
         db_ipts = list(ipt_args.keys())
         tbl_ipts = [list(ipt_args[ipt_db].keys()) for ipt_db in ipt_args]
 
-        db_tbls = sum(
+        db_tbls = functools.reduce(
+            operator.iadd,
             [
                 list(zip([db_ipts[i]] * len(tbl_ipts[i]), tbl_ipts[i]))
                 for i in range(len(db_ipts))
@@ -616,11 +610,9 @@ class AthenaTransformEngine(BaseTransformEngine):
 
         except Exception as e:
             _logger.info(
-                (
-                    "Failed to write data to derived.\n"
-                    f"Error: {e}\n"
-                    "Deleting any half-written files.\n"
-                )
+                "Failed to write data to derived.\n"
+                f"Error: {e}\n"
+                "Deleting any half-written files.\n"
             )
 
             for prt in partitions:
@@ -654,7 +646,7 @@ class AthenaTransformEngine(BaseTransformEngine):
         self,
         tables: list[str],
         stage: str = "create_derived",
-        jinja_args: dict[str, Any] = {},
+        jinja_args: dict[str, Any] | None = None,
     ) -> None:
         """Creates derived tables for db using Athena
 
@@ -674,6 +666,8 @@ class AthenaTransformEngine(BaseTransformEngine):
         **jinja_args: dict[str, Any]
             Jinja args to pass to pydbtools calls.
         """
+        if jinja_args is None:
+            jinja_args = {}
         if stage != "create_derived":
             raise ValueError("Expecting derived ETL step for this transform")
 

--- a/src/opg_pipeline_builder/transform_engines/base.py
+++ b/src/opg_pipeline_builder/transform_engines/base.py
@@ -1,6 +1,6 @@
 import logging
 from inspect import getmembers, isfunction, signature
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -14,7 +14,7 @@ _logger: logging.Logger = logging.getLogger(__name__)
 class BaseTransformEngine(BaseModel):
     config: PipelineConfig
     db: Database
-    utils: Optional[TransformEngineUtils] = None
+    utils: TransformEngineUtils | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -25,14 +25,7 @@ class BaseTransformEngine(BaseModel):
 
     @staticmethod
     def _check_public_method_args(parameters: list[str]) -> bool:
-        if "tables" not in parameters:
-            return False
-
-        if "stages" or "stage" in parameters:
-            return True
-
-        else:
-            return False
+        return "tables" in parameters
 
     def _validate_method_kwargs(self) -> None:
         methods = [
@@ -42,10 +35,8 @@ class BaseTransformEngine(BaseModel):
         ]
 
         validation = all(
-            [
-                BaseTransformEngine._check_public_method_args(parameters)  # type: ignore
-                for parameters in methods
-            ]
+            BaseTransformEngine._check_public_method_args(parameters)  # type: ignore
+            for parameters in methods
         )
 
         if not validation:

--- a/src/opg_pipeline_builder/transform_engines/catalog.py
+++ b/src/opg_pipeline_builder/transform_engines/catalog.py
@@ -50,23 +50,21 @@ class CatalogTransformEngine(BaseTransformEngine):
                 _logger.info(f"Creating initial {db_name} db")
                 glue_client.create_database(**db_meta)
             else:
-                _logger.info("Unexpected error: %s" % e)
+                _logger.info(f"Unexpected error: {e}")
 
-        for table in tables:
-            _logger.info(f"Updating {db_name}.{table}")
-            db_table = db.table(table)
+        for table_name in tables:
+            _logger.info(f"Updating {db_name}.{table_name}")
+            db_table = db.table(table_name)
 
             stage_meta = db_table.get_table_metadata("curated")
             stage_meta.force_partition_order = "start"
             stage_s3_path = db_table.get_table_path("curated")
 
-            if table != stage_meta.name:
+            if table_name != stage_meta.name:
                 raise ValueError(
-                    (
-                        "Table name in metadata file is inconsistent:\n"
-                        f"{stage_meta.name} (meta)\n"
-                        f"{table} (config)"
-                    )
+                    "Table name in metadata file is inconsistent:\n"
+                    f"{stage_meta.name} (meta)\n"
+                    f"{table_name} (config)"
                 )
 
             wr.catalog.delete_table_if_exists(database=db_name, table=stage_meta.name)
@@ -78,8 +76,8 @@ class CatalogTransformEngine(BaseTransformEngine):
             )
 
             glue_client.create_table(**spec)
-            wr.athena.repair_table(table=table, database=db_name)
+            wr.athena.repair_table(table=table_name, database=db_name)
 
-            _logger.info(f"{db_name}.{table} updated")
+            _logger.info(f"{db_name}.{table_name} updated")
 
         _logger.info(f"Finished updating {db_name}")

--- a/src/opg_pipeline_builder/transform_engines/data_linter.py
+++ b/src/opg_pipeline_builder/transform_engines/data_linter.py
@@ -9,6 +9,7 @@ import awswrangler as wr
 from data_linter import validation
 from dataengineeringutils3.s3 import get_filepaths_from_s3_folder
 from jsonschema import exceptions, validate
+from pydantic import Field
 
 from opg_pipeline_builder.models.metadata_model import MetaData
 from opg_pipeline_builder.utils.constants import (
@@ -37,7 +38,7 @@ class DataLinterTransformEngine(BaseTransformEngine):
         if temp_staging is set to True in mp_args.
     """
 
-    mp_args: dict[Any, Any] = {}
+    mp_args: dict[Any, Any] = Field(default_factory=dict)
     dag_timestamp: int | None = get_dag_timestamp()
 
     @staticmethod
@@ -58,7 +59,7 @@ class DataLinterTransformEngine(BaseTransformEngine):
         }
 
         if mp_args:
-            if "enable" not in mp_args.keys():
+            if "enable" not in mp_args:
                 raise KeyError('mp_args must contain an "enable" key-value pair')
 
             mp_enable = mp_args["enable"]
@@ -97,10 +98,8 @@ class DataLinterTransformEngine(BaseTransformEngine):
                 config_dc = deepcopy(config)
 
                 _logger.info(
-                    (
-                        f"Creating parallel run config files for {max_workers}"
-                        " (CPU count) workers"
-                    )
+                    f"Creating parallel run config files for {max_workers}"
+                    " (CPU count) workers"
                 )
                 validation.para_run_init(max_workers, config_dc)
 
@@ -111,10 +110,8 @@ class DataLinterTransformEngine(BaseTransformEngine):
                 if current_worker is None and close_status is False:
                     max_workers = mp_args["total_workers"]
                     _logger.info(
-                        (
-                            f"Creating parallel run config files for {max_workers}"
-                            " (environment) workers"
-                        )
+                        f"Creating parallel run config files for {max_workers}"
+                        " (environment) workers"
                     )
                     validation.para_run_init(max_workers, config)
 
@@ -129,7 +126,7 @@ class DataLinterTransformEngine(BaseTransformEngine):
 
         elif mp_args["enable"] == "local":
             max_workers: int = os.cpu_count()  # type: ignore
-            workers = range(0, max_workers)
+            workers = range(max_workers)
             config_dc = [deepcopy(config) for _ in workers]
             _logger.info(f"Running validation with {max_workers} workers")
 
@@ -190,12 +187,10 @@ class DataLinterTransformEngine(BaseTransformEngine):
             tmp_staging = mp_args.get("temp_staging", False)
             tmp_staging = False if tmp_staging is None else tmp_staging
 
-            if mp_enable == "local" and tmp_staging:
+            if (mp_enable == "local" and tmp_staging) or (
+                mp_enable == "pod" and mp_args["close_status"] and tmp_staging
+            ):
                 proceed = True
-
-            elif mp_enable == "pod":
-                if mp_args["close_status"] and tmp_staging:
-                    proceed = True
 
         if proceed:
             pass_tmp_path = config["pass-base-path"]  # type: ignore

--- a/src/opg_pipeline_builder/transform_engines/pandas.py
+++ b/src/opg_pipeline_builder/transform_engines/pandas.py
@@ -1,11 +1,12 @@
 import logging
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import awswrangler as wr
 from arrow_pd_parser import reader, writer
 from mojap_metadata import Metadata
+from pydantic import Field
 
 from opg_pipeline_builder.models.metadata_model import MetaData
 
@@ -20,14 +21,14 @@ class PandasTransformEngine(EnrichMetaTransformEngine):
     chunk_rest_threshold: int = 500_000_000
     add_partition_column: bool = False
     attributes_file: str = ""
-    attributes: dict[Any, Any] = {}
-    extract_header_values: dict[str, str] = {}
+    attributes: dict[Any, Any] = Field(default_factory=dict)
+    extract_header_values: dict[str, str] = Field(default_factory=dict)
     enrich_meta: bool = True
     raw_stage: str = "raw_hist"
     final_partition_stage: str = "curated"
-    transforms: Optional[PandasTransformations] = None
+    transforms: PandasTransformations | None = None
 
-    def model_post_init(self, __context) -> None:  # type: ignore
+    def model_post_init(self, __context: Any, /) -> None:
         super().model_post_init(__context)
         self.transforms = PandasTransformations(
             config=self.config,
@@ -86,8 +87,7 @@ class PandasTransformEngine(EnrichMetaTransformEngine):
         )
 
         _logger.info("Looping through chunks")
-        i = 0
-        for df in dfs:
+        for i, df in enumerate(dfs):
             _logger.info(f"Transforming chunk {i}")
             if transform_type == "custom":
                 tf_df = self.transforms.custom_transform(  # type: ignore
@@ -118,7 +118,6 @@ class PandasTransformEngine(EnrichMetaTransformEngine):
                 output_path=output_filepath,
                 metadata=output_meta,
             )
-            i += 1
 
     def _apply(
         self,

--- a/src/opg_pipeline_builder/transform_engines/transforms/panda.py
+++ b/src/opg_pipeline_builder/transform_engines/transforms/panda.py
@@ -9,6 +9,7 @@ import pandas as pd
 from dataengineeringutils3.s3 import read_json_from_s3
 from jinja2 import Template
 from mojap_metadata import Metadata
+from pydantic import Field
 
 from opg_pipeline_builder.transform_engines.transforms.base import BaseTransformations
 
@@ -18,8 +19,8 @@ _logger: logging.Logger = logging.getLogger(__name__)
 class PandasTransformations(BaseTransformations):  # type: ignore
     add_partition_column: bool = False
     attributes_file: str = ""
-    attributes: dict[Any, Any] = {}
-    extract_header_values: dict[str, str] = {}
+    attributes: dict[Any, Any] = Field(default_factory=dict)
+    extract_header_values: dict[str, str] = Field(default_factory=dict)
 
     @staticmethod
     def remove_columns_not_in_metadata(
@@ -51,7 +52,7 @@ class PandasTransformations(BaseTransformations):  # type: ignore
             header_values = [(c, v[0]) for c, v in header_values if v is not None]  # type: ignore
             headers_in_scope = [c for c, _ in header_values]
 
-            unique_values = set([v for _, v in header_values])
+            unique_values = {v for _, v in header_values}
 
             mapping = [
                 {

--- a/src/opg_pipeline_builder/transform_engines/utils/athena.py
+++ b/src/opg_pipeline_builder/transform_engines/utils/athena.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import awswrangler as wr
 import boto3
 import pydbtools as pydb
@@ -25,7 +23,7 @@ class AthenaTransformEngineUtils(TransformEngineUtils):  # type: ignore
     def recreate_database(
         self,
         database_name: str,
-        existing_databases: Optional[list[str] | None] = None,
+        existing_databases: list[str] | None = None,
     ) -> None:
         if existing_databases is None:
             databases_df = wr.catalog.databases(limit=self.db_search_limit)

--- a/src/opg_pipeline_builder/transform_engines/utils/utils.py
+++ b/src/opg_pipeline_builder/transform_engines/utils/utils.py
@@ -79,7 +79,9 @@ class TransformEngineUtils(BaseModel):
         if modified_before is None and disable_environment is False:
             modified_before = get_end_date()
 
-        table = self.db.table(table_name)
+        table = self.db.table(
+            table_name.split("-")[-1]
+        )  # Remove schema prefix if present
         etl_stages = deepcopy(table.etl_stages())
         table_paths = table.table_data_paths()
 

--- a/src/opg_pipeline_builder/transform_engines/utils/utils.py
+++ b/src/opg_pipeline_builder/transform_engines/utils/utils.py
@@ -208,15 +208,15 @@ class TransformEngineUtils(BaseModel):
 
         new_partitions = [f for f in input_partitions if f not in output_partitions]
 
-        new_partitions_list: list[str] = sorted(list(set(new_partitions)), reverse=True)  # type: ignore
+        new_partitions_list: list[str] = sorted(set(new_partitions), reverse=True)  # type: ignore
 
         return new_partitions_list
 
     def transform_partitions(
         self,
-        tables: list[str] | None = get_source_tbls(),
-        stages: dict[str, str] = {"input": "raw_hist", "output": "curated"},
-        tf_types: list[str] = ["default", "custom"],
+        tables: list[str] | None = None,
+        stages: dict[str, str] | None = None,
+        tf_types: list[str] | None = None,
     ) -> dict[str, list[str] | list[int]]:
         """Lists unprocessed partitions for a set of tables
 
@@ -243,6 +243,12 @@ class TransformEngineUtils(BaseModel):
             Dictionary containing list of unprocessed partitions for
             the tables passed, given the ETL stages specified.
         """
+        if tf_types is None:
+            tf_types = ["default", "custom"]
+        if stages is None:
+            stages = {"input": "raw_hist", "output": "curated"}
+        if tables is None:
+            tables = get_source_tbls()
         stages_list = [v for _, v in stages.items()]
         tables_to_use = self.db.tables_to_use(
             tables, stages=stages_list, tf_types=tf_types
@@ -258,7 +264,7 @@ class TransformEngineUtils(BaseModel):
     def tf_args(
         self,
         table_name: str,
-        stages: dict[str, str] = {"input": "raw_hist", "output": "curated"},
+        stages: dict[str, str] | None = None,
     ) -> tuple[str, str, str]:
         """Transformation arguments for specified table
 
@@ -281,6 +287,8 @@ class TransformEngineUtils(BaseModel):
             transform type, input S3 path and output S3 path
             for the given table and stages.
         """
+        if stages is None:
+            stages = {"input": "raw_hist", "output": "curated"}
         transform_stage_args = {table_name: stages}
 
         tf_args = self.db.transform_args([table_name], **transform_stage_args)

--- a/src/opg_pipeline_builder/transforms.py
+++ b/src/opg_pipeline_builder/transforms.py
@@ -28,7 +28,7 @@ class Transforms:
         base_engine = importlib.import_module(
             ".base", package=transform_engines.__package__
         )
-        base_engine_class = getattr(base_engine, "BaseTransformEngine")
+        base_engine_class = base_engine.BaseTransformEngine
 
         if key in self.__dict__:
             try:

--- a/src/opg_pipeline_builder/utils/constants.py
+++ b/src/opg_pipeline_builder/utils/constants.py
@@ -222,7 +222,7 @@ def get_use_glue() -> bool:
     try:
         glue_enable: bool = literal_eval(os.environ["USE_GLUE"])
         if not isinstance(glue_enable, bool):
-            raise ValueError(
+            raise TypeError(
                 "Expecting True or False for 'USE_GLUE' environment variable"
             )
     except KeyError:
@@ -293,9 +293,9 @@ def get_full_db_name(
     env_suffix = f"derived_{env}" if derived else env
 
     if db_name == "all":
-        full_db_name = "_".join([prefix, env_suffix])
+        full_db_name = f"{prefix}_{env_suffix}"
     else:
-        full_db_name = "_".join([prefix, db_name, env_suffix])
+        full_db_name = f"{prefix}_{db_name}_{env_suffix}"
 
     return full_db_name
 
@@ -349,7 +349,7 @@ def get_chunk_size() -> int | bool:
         chunk: int = literal_eval(chunk_str)
 
         if not isinstance(chunk, bool) and not isinstance(chunk, int):
-            raise ValueError(
+            raise TypeError(
                 "CHUNK_SIZE must be a string corresponding to a boolean or integer"
             )
 
@@ -377,5 +377,5 @@ def get_dag_timestamp() -> int | None:
     try:
         dag_ts = int(os.environ["RUN_TIMESTAMP"])
         return dag_ts
-    except Exception:  # pylint: disable=broad-exception-caught
+    except (KeyError, TypeError, ValueError):
         return None

--- a/src/opg_pipeline_builder/utils/schema_reader.py
+++ b/src/opg_pipeline_builder/utils/schema_reader.py
@@ -170,11 +170,11 @@ class SchemaReader:
 
         ds_map = {}
         for ds_col in col_type:
-            ds_name, ds_type = list(ds_col.items())[0]
+            ds_name, ds_type = next(iter(ds_col.items()))
             ds_map[ds_name] = ds_type
 
         for ms_col in meta_col_type:
-            ms_name, ms_type = list(ms_col.items())[0]  # type: ignore
+            ms_name, ms_type = next(iter(ms_col.items()))  # type: ignore
             if ms_name in ds_map:
                 cds_type = ds_map[ms_name]
                 if isinstance(ms_type, str):

--- a/src/opg_pipeline_builder/utils/utils.py
+++ b/src/opg_pipeline_builder/utils/utils.py
@@ -2,9 +2,9 @@ import glob
 import os
 import re
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import boto3
 from dataengineeringutils3.s3 import (
@@ -34,9 +34,7 @@ def get_last_modified(obj: dict[Any, Any]) -> int:
     return int(obj["LastModified"].strftime("%s"))
 
 
-def s3_copy(
-    copy_args: tuple[str, str], client: Optional[boto3.client] = None
-) -> dict[Any, Any]:
+def s3_copy(copy_args: tuple[str, str], client: boto3.client) -> dict[Any, Any]:
     """
     Function to copy objects from one S3 location to another S3 location
     Args:
@@ -200,9 +198,8 @@ def get_modified_filepaths_from_s3_folder(
 
     s3_resource = boto3.resource("s3")
 
-    if file_extension is not None:
-        if file_extension[0] != ".":
-            file_extension = "." + file_extension
+    if file_extension is not None and file_extension[0] != ".":
+        file_extension = "." + file_extension
 
     # This guarantees that the path the user has given is really a 'folder'.
     s3_folder_path = _add_slash(s3_folder_path)
@@ -264,8 +261,8 @@ def _get_file_result(max_existing_ts: int, new_ts: int, one_a_day: bool) -> bool
         else:
             get_file = False
     else:
-        max_date = datetime.fromtimestamp(max_existing_ts).date()
-        new_file_date = datetime.fromtimestamp(new_ts).date()
+        max_date = datetime.fromtimestamp(max_existing_ts, tz=UTC).date()
+        new_file_date = datetime.fromtimestamp(new_ts, tz=UTC).date()
         if max_date < new_file_date:
             get_file = True
         else:
@@ -299,23 +296,19 @@ def check_s3_for_existing_timestamp_file(
         # get max timestamp in raw_hist for given table
         ts = [re.search(filename_regex, Path(i).name).group(3) for i in existing_data]  # type: ignore
     except AttributeError:
-        raise ValueError(
-            """a file timestamp in raw_hist is not
-               in the expected format"""
-        )
+        raise ValueError("""a file timestamp in raw_hist is not
+               in the expected format""")
 
     try:
         max_ts = int(max(ts))
-    except Exception:
+    except (TypeError, ValueError):
         max_ts = 0
 
     try:
         new_file_timestamp = re.search(filename_regex, Path(new_file).name).group(3)  # type: ignore
     except AttributeError:
-        raise ValueError(
-            f"""the new filename, {new_file}, is not
-               in the expected format"""
-        )
+        raise ValueError(f"""the new filename, {new_file}, is not
+               in the expected format""")
 
     if not isinstance(new_file_timestamp, int) and not len(new_file_timestamp) == 10:
         raise ValueError("wrong format for new timestamp")

--- a/src/opg_pipeline_builder/validator.py
+++ b/src/opg_pipeline_builder/validator.py
@@ -39,9 +39,8 @@ class TableConfig(BaseModel):
                     f"{self.transform_type} table should not have input_data"
                 )
 
-            if self.transform_type == "default":
-                if self.sql:
-                    raise ValueError("default table should not have sql")
+            if self.transform_type == "default" and self.sql:
+                raise ValueError("default table should not have sql")
 
         return self
 
@@ -122,7 +121,7 @@ class PipelineConfig(BaseModel):
     @field_validator("paths")
     @classmethod
     def check_in_etl_stages(cls, v: dict[str, str]) -> dict[str, str]:
-        stage = [k for k in v][0]
+        stage = next(iter(v))
         if stage not in etl_stages:
             raise ValueError(f"{stage} is not a valid ETL stage")
         return v
@@ -130,7 +129,7 @@ class PipelineConfig(BaseModel):
     @field_validator("shared_sql")
     @classmethod
     def check_in_transform_types(cls, v: dict[str, list[str]]) -> dict[str, list[str]]:
-        transform_type = [k for k, _ in v.items()][0]
+        transform_type = next(k for k, _ in v.items())
         valid_type = transform_type in transform_types
         error_message = f"{transform_type} is not one of {', '.join(transform_types)}"
         if not valid_type:
@@ -235,12 +234,10 @@ class PipelineConfig(BaseModel):
                 table_tf = table.transform_type
 
                 if table_tf != "derived":
-                    try:
-                        lint_opt = table.lint_options
-                        full_lint_config["tables"][table_name] = lint_opt
-
-                    except Exception:
+                    lint_opt = table.lint_options
+                    if lint_opt is None:
                         raise KeyError(f"{table} does not have lint options")
+                    full_lint_config["tables"][table_name] = lint_opt
 
             dummy_s3_paths = {
                 "land-base-path": "s3://testing-bucket/land/",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,12 @@ import logging
 import os
 import pathlib
 import shutil
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, Callable, Generator
+from typing import Any
 from unittest.mock import MagicMock
 
 import aiobotocore.awsrequest
@@ -256,9 +257,9 @@ class MockS3FilesystemReadInputStream:
     def open_input_file(s3_file_path_in: str) -> Generator[str, None, None]:
         s3_client = boto3.client("s3")
         bucket, key = s3_path_to_bucket_key(s3_file_path_in)
-        tmp_file = NamedTemporaryFile(suffix=pathlib.Path(key).suffix)
-        s3_client.download_file(bucket, key, tmp_file.name)
-        yield tmp_file.name
+        with NamedTemporaryFile(suffix=pathlib.Path(key).suffix) as tmp_file:
+            s3_client.download_file(bucket, key, tmp_file.name)
+            yield tmp_file.name
 
 
 def mock_get_file(*args: Any, **kwargs: Any) -> MockS3FilesystemReadInputStream:

--- a/tests/test_athena_engine.py
+++ b/tests/test_athena_engine.py
@@ -1,7 +1,7 @@
 import os
 import re
 from copy import deepcopy
-from datetime import datetime
+from datetime import UTC, datetime
 from functools import partial
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
@@ -19,8 +19,8 @@ from arrow_pd_parser import reader, writer
 from mojap_metadata.converters.glue_converter import GlueConverter, GlueTable
 from moto import mock_aws
 
-import opg_pipeline_builder.transform_engines.athena as athena
 from opg_pipeline_builder.database import Database
+from opg_pipeline_builder.transform_engines import athena
 from opg_pipeline_builder.utils.constants import get_full_db_name
 from opg_pipeline_builder.validator import PipelineConfig
 from tests.conftest import mock_get_file, set_up_s3
@@ -81,11 +81,11 @@ class TestAthenaTransformEngine:
 
         tables = [table for table in sqlglot.parse_one(sql).find_all(sqlglot.exp.Table)]
 
-        table = [
+        table = next(
             id.name
             for id in tables[0].find_all(sqlglot.exp.Identifier)
             if id.name != database
-        ][0]
+        )
 
         glue_client = boto3.client("glue")
 
@@ -107,12 +107,12 @@ class TestAthenaTransformEngine:
                 os.remove(database_to_use)
 
             con = duckdb.connect(database=database_to_use)
-            tmp_file = NamedTemporaryFile(suffix=".snappy.parquet")
-            wr.s3.download(path=p, local_file=tmp_file.name)
+            with NamedTemporaryFile(suffix=".snappy.parquet") as tmp_file:
+                wr.s3.download(path=p, local_file=tmp_file.name)
 
-            df = reader.read(  # noqa: F841
-                tmp_file.name, metadata=glue_meta if use_glue_meta else None
-            )
+                df = reader.read(  # noqa: F841
+                    tmp_file.name, metadata=glue_meta if use_glue_meta else None
+                )
             prt = extract_mojap_timestamp(
                 extract_mojap_partition(p, timestamp_partition_name=primary_partition)
             )
@@ -164,9 +164,9 @@ class TestAthenaTransformEngine:
         primary_partition: str,
         s3_path: str,
     ) -> None:
-        tmp_file = NamedTemporaryFile(suffix=".snappy.parquet")
-        wr.s3.download(path=s3_path, local_file=tmp_file.name)
-        mock_df = reader.read(tmp_file.name)  # noqa: F841
+        with NamedTemporaryFile(suffix=".snappy.parquet") as tmp_file:
+            wr.s3.download(path=s3_path, local_file=tmp_file.name)
+            mock_df = reader.read(tmp_file.name)  # noqa: F841
 
         duckdb_sql = sqlglot.transpile(sql, read="presto", write="duckdb")
 
@@ -205,18 +205,18 @@ class TestAthenaTransformEngine:
         table_meta.partitions = []
 
         df = reader.read(self.raw_data_file, metadata=table_meta)
-        tmp = NamedTemporaryFile(suffix=".snappy.parquet")
-        writer.write(df, tmp.name, metadata=table_meta)
-        timestamp = int(datetime.now().timestamp())
+        with NamedTemporaryFile(suffix=".snappy.parquet") as tmp:
+            writer.write(df, tmp.name, metadata=table_meta)
+            timestamp = int(datetime.now(tz=UTC).timestamp())
 
-        wr.s3.upload(
-            tmp.name,
-            os.path.join(
-                paths[stage],
-                f"{partition_name}={timestamp}",
-                f"{Path(self.raw_data_file).stem}.snappy.parquet",
-            ),
-        )
+            wr.s3.upload(
+                tmp.name,
+                os.path.join(
+                    paths[stage],
+                    f"{partition_name}={timestamp}",
+                    f"{Path(self.raw_data_file).stem}.snappy.parquet",
+                ),
+            )
 
         return athena, timestamp  # type: ignore[return-value]
 
@@ -266,9 +266,9 @@ class TestAthenaTransformEngine:
             files = wr.s3.list_objects(path=cp)
 
             for i, file in enumerate(files):
-                tmp = NamedTemporaryFile(suffix=".snappy.parquet")
-                wr.s3.download(file, tmp.name)
-                file_df = reader.read(tmp.name, metadata=output_meta)
+                with NamedTemporaryFile(suffix=".snappy.parquet") as tmp:
+                    wr.s3.download(file, tmp.name)
+                    file_df = reader.read(tmp.name, metadata=output_meta)
                 original_prts = [
                     prt for prt in copied_meta.partitions if prt != primary_partition
                 ]
@@ -313,7 +313,7 @@ class TestAthenaTransformEngine:
             )
 
         else:
-            with pytest.raises(Exception):
+            with pytest.raises(ValueError):
                 transform.run(
                     stage=self.input_stage,
                     table=table.name,
@@ -430,9 +430,9 @@ class TestAthenaTransformEngine:
             files = wr.s3.list_objects(path=dp)
 
             for i, file in enumerate(files):
-                tmp = NamedTemporaryFile(suffix=".snappy.parquet")
-                wr.s3.download(file, tmp.name)
-                file_df = reader.read(tmp.name)
+                with NamedTemporaryFile(suffix=".snappy.parquet") as tmp:
+                    wr.s3.download(file, tmp.name)
+                    file_df = reader.read(tmp.name)
                 original_prts = [
                     prt for prt in copied_meta.partitions if prt != primary_partition
                 ]
@@ -455,7 +455,7 @@ class TestAthenaTransformEngine:
             assert set(df.animal) == {"chicken"}
 
         else:
-            with pytest.raises(Exception):
+            with pytest.raises(ValueError):
                 transform.run_derived(tables=[table.name])
             assert len(wr.s3.list_objects(dp)) == 0
             assert len(wr.s3.list_objects(temp_path)) == 0

--- a/tests/test_base_engine.py
+++ b/tests/test_base_engine.py
@@ -134,10 +134,10 @@ class TestBaseEngineTransform:
                 assert transform.utils.list_table_files(  # type: ignore[union-attr]
                     stage, table, modified_before=mid_adj_timestamp
                 ) == [
-                    [
+                    next(
                         f"s3://{getattr(self, stage_bucket)}/{p[path_index]}"
                         for p in setup[i]
-                    ][0]
+                    )
                 ]
 
                 assert transform.utils.list_table_files(  # type: ignore[union-attr]
@@ -320,7 +320,7 @@ class TestBaseEngineTransform:
         env = transform.db.env
         db_name = transform.db.name
 
-        for _, map in stages_map.items():
+        for map in stages_map.values():
             stage = map["name"]
             bucket = map["bucket_name"]
             setup: list[tuple[str, str, str]] = []
@@ -429,7 +429,7 @@ class TestBaseEngineTransform:
         env = transform.db.env
         db_name = transform.db.name
 
-        for _, map in stages_map.items():
+        for map in stages_map.values():
             stage = map["name"]
             bucket = map["bucket_name"]
             setup: list[tuple[str, str, str]] = []

--- a/tests/test_catalog_engine.py
+++ b/tests/test_catalog_engine.py
@@ -7,9 +7,9 @@ import pytest
 from mojap_metadata.converters.glue_converter import GlueConverter, GlueTable
 from moto import mock_aws
 
-import opg_pipeline_builder.transform_engines.catalog as catalog
 from opg_pipeline_builder.database import Database
 from opg_pipeline_builder.models.metadata_model import load_metadata
+from opg_pipeline_builder.transform_engines import catalog
 from opg_pipeline_builder.utils.constants import get_full_db_name
 from opg_pipeline_builder.validator import PipelineConfig
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -135,7 +135,7 @@ def test_get_use_glue(
     else:
         os.environ["USE_GLUE"] = enable_glue
         if error:
-            with pytest.raises(ValueError):
+            with pytest.raises(TypeError):
                 get_use_glue()
         else:
             ug = get_use_glue()
@@ -159,7 +159,7 @@ def test_get_no_glue_workers(
     from opg_pipeline_builder.utils.constants import get_no_glue_workers, get_use_glue
 
     if use_glue is None:
-        if "USE_GLUE" in os.environ.keys():
+        if "USE_GLUE" in os.environ:
             del os.environ["USE_GLUE"]
         n_wrks = get_no_glue_workers()
         assert n_wrks == expected
@@ -170,11 +170,11 @@ def test_get_no_glue_workers(
         try:
             _ = get_use_glue()
             error = False
-        except ValueError:
+        except TypeError:
             error = True
 
         if error:
-            with pytest.raises(ValueError):
+            with pytest.raises(TypeError):
                 get_no_glue_workers()
         else:
             assert get_no_glue_workers() == expected

--- a/tests/test_data_linter_engine.py
+++ b/tests/test_data_linter_engine.py
@@ -105,7 +105,7 @@ class TestDataLinterEngine:
         config: PipelineConfig,
         database: Database,
     ) -> None:
-        import pyarrow.fs as fs
+        from pyarrow import fs
 
         monkeypatch.setattr(fs, "S3FileSystem", mock_get_file)
 
@@ -140,7 +140,7 @@ class TestDataLinterEngine:
             s3.meta.client.upload_file(
                 dummy_data_path / path,
                 lb,
-                os.path.join(lk, table.name, dummy_data[i]),
+                os.path.join(lk, table.name, path),
             )
 
         if mps_list:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -7,8 +7,7 @@ import yaml
 from mojap_metadata import Metadata
 
 from opg_pipeline_builder.database import Database, DatabaseTable
-from opg_pipeline_builder.validator import read_pipeline_config
-from opg_pipeline_builder.validator import PipelineConfig
+from opg_pipeline_builder.validator import PipelineConfig, read_pipeline_config
 from tests.conftest import land_bucket
 
 
@@ -492,7 +491,7 @@ def test_db_lint_config(
     for table in test_tables:
         tf_args_tfs = expected["transform_args"]["transforms"]
         tbl_tf = tf_args_tfs[table]["transform_type"]
-        if table in exp_lint_config["tables"].keys() and tbl_tf in [
+        if table in exp_lint_config["tables"] and tbl_tf in [
             "default",
             "custom",
         ]:

--- a/tests/test_metadata/test_metadata_model.py
+++ b/tests/test_metadata/test_metadata_model.py
@@ -17,9 +17,13 @@ def create_stage(
 def create_column(
     name: str = "id",
     nullable: bool = True,
-    enum: list[str | int] = ["A", "B"],
-    stages: list[m.Stage] = [create_stage()],
+    enum: list[str | int] | None = None,
+    stages: list[m.Stage] | None = None,
 ) -> m.Column:
+    if stages is None:
+        stages = [create_stage()]
+    if enum is None:
+        enum = ["A", "B"]
     return m.Column(name=name, nullable=nullable, enum=enum, stages=stages)
 
 
@@ -578,7 +582,7 @@ def test_output_to_df() -> None:
 def test_load_metadata() -> None:
     metadata = m.load_metadata(Path("tests/data/meta_data"), "test_database")
 
-    assert sorted(list(metadata.tables.keys())) == ["test_table", "test_table2"]
+    assert sorted(metadata.tables.keys()) == ["test_table", "test_table2"]
     assert metadata.tables["test_table"].columns[0].name == "id"
     assert metadata.tables["test_table2"].columns[0].name == "ids"
 

--- a/tests/test_pandas_engine.py
+++ b/tests/test_pandas_engine.py
@@ -1,18 +1,18 @@
 import json
+from collections.abc import Generator
 from copy import deepcopy
-from datetime import datetime
+from datetime import UTC, datetime
 from logging import getLogger
-from typing import Generator, Type
 
 import awswrangler as wr
 import boto3
 import numpy as np
 import pandas as pd
-import pyarrow.fs as fs
 import pytest
 from arrow_pd_parser import reader, writer
 from mojap_metadata import Metadata
 from moto import mock_aws
+from pyarrow import fs
 
 from opg_pipeline_builder.database import Database
 from opg_pipeline_builder.transform_engines.pandas import PandasTransformEngine
@@ -26,7 +26,7 @@ DEFAULT_METADATA_FILE = "tests/data/meta_data/test/testdb/raw_hist/table1.json"
 
 
 @pytest.fixture
-def pandas_engine_class() -> Generator[Type[PandasTransformEngine], None, None]:
+def pandas_engine_class() -> Generator[type[PandasTransformEngine], None, None]:
     yield PandasTransformEngine
 
 
@@ -35,7 +35,7 @@ def pandas_engine(
     pandas_engine_class: PandasTransformEngine,
     config: PipelineConfig,
     database: Database,
-) -> Generator[Type[PandasTransformEngine], None, None]:
+) -> Generator[type[PandasTransformEngine], None, None]:
     yield pandas_engine_class(config=config, db=database)  # type: ignore[operator]
 
 
@@ -68,7 +68,7 @@ def test_set_column_names_to_lower(
     pandas_engine: PandasTransformEngine, default_df: pd.DataFrame
 ) -> None:
     df = pandas_engine.transforms.set_colnames_to_lower(default_df)  # type: ignore[union-attr]
-    assert all([c.islower() for c in df.columns.to_list()])
+    assert all(c.islower() for c in df.columns.to_list())
 
 
 def test_add_attributes_from_headers_and_rename(
@@ -110,8 +110,8 @@ def test_add_primary_partition_column(
     config: PipelineConfig,
     database: Database,
 ) -> None:
-    ts = int(datetime.utcnow().timestamp())
-    partition_value = f"mojap_file_land_timestamp={str(ts)}"
+    ts = int(datetime.now(tz=UTC).timestamp())
+    partition_value = f"mojap_file_land_timestamp={ts!s}"
 
     pandas_engine = pandas_engine_class(  # type: ignore[operator]
         add_partition_column=True, config=config, db=database
@@ -308,7 +308,7 @@ def test_output_transform_methods(
 
     if attributes:
         default_metadata.update_column(
-            {"name": list(attributes.keys())[0], "type": "string"}
+            {"name": next(iter(attributes.keys())), "type": "string"}
         )
 
     input_df = default_df.copy()
@@ -324,8 +324,8 @@ def test_output_transform_methods(
     expected_df["testdb_etl_version"] = "testing"
 
     if add_partition_column:
-        ts = int(datetime.utcnow().timestamp())
-        partition_value = f"mojap_file_land_timestamp={str(ts)}"
+        ts = int(datetime.now(tz=UTC).timestamp())
+        partition_value = f"mojap_file_land_timestamp={ts!s}"
         expected_df["mojap_file_land_timestamp"] = ts
         default_metadata.update_column(
             {"name": "mojap_file_land_timestamp", "type": "int64"}
@@ -415,7 +415,7 @@ def test_transform(
         }
     )
 
-    ts = int(datetime.utcnow().timestamp())
+    ts = int(datetime.now(tz=UTC).timestamp())
     partition = f"mojap_file_land_timestamp={ts}"
 
     input_partition_path = (

--- a/tests/test_schema_reader.py
+++ b/tests/test_schema_reader.py
@@ -25,17 +25,17 @@ class TestSchemaReader:
 
         set_up_s3(s3)
 
-        tmp_file = NamedTemporaryFile(suffix=file_ext)
         df = self.data
         meta = self.meta
 
-        if file_ext == "snappy.parquet":
-            writer.parquet.write(df, output_path=tmp_file.name, metadata=meta)
-        else:
-            writer.json.write(df, output_path=tmp_file.name, metadata=meta)
+        with NamedTemporaryFile(suffix=file_ext) as tmp_file:
+            if file_ext == "snappy.parquet":
+                writer.parquet.write(df, output_path=tmp_file.name, metadata=meta)
+            else:
+                writer.json.write(df, output_path=tmp_file.name, metadata=meta)
 
-        s3_key = f"dummy_data.{file_ext}"
-        s3.meta.client.upload_file(tmp_file.name, dummy_bucket, s3_key)
+            s3_key = f"dummy_data.{file_ext}"
+            s3.meta.client.upload_file(tmp_file.name, dummy_bucket, s3_key)
 
         return s3_key
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 from opg_pipeline_builder.transform_engines.athena import AthenaTransformEngine
 from opg_pipeline_builder.transform_engines.base import BaseTransformEngine
 from opg_pipeline_builder.transforms import Transforms
@@ -11,13 +9,13 @@ class TestTransforms:
     def get_transforms(self) -> Transforms:
         return Transforms()
 
-    def setup_child_athena(self) -> Type[AthenaTransformEngine]:
+    def setup_child_athena(self) -> type[AthenaTransformEngine]:
         class ChildAthenaTransformEngine(AthenaTransformEngine):
             def dummy_method(self, _: list[str], __: dict[str, str]) -> None: ...
 
         return ChildAthenaTransformEngine
 
-    def setup_dummy_engine(self) -> Type[BaseTransformEngine]:
+    def setup_dummy_engine(self) -> type[BaseTransformEngine]:
         class DummyTransformEngine(BaseTransformEngine):
             def run(self, _: list[str], __: dict[str, str]) -> None:
                 print("hello")

--- a/uv.lock
+++ b/uv.lock
@@ -241,30 +241,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.90"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/17/510f31d7d6190c01725710d95415733e467f4406d450a106f6eacfd3a94d/boto3-1.42.90.tar.gz", hash = "sha256:bafb5bb1dea262ac95f9afb1e415f06a9490f05cb203bdd897d0afdcd17733c6", size = 113174, upload-time = "2026-04-16T20:27:43.012Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/65/47670987f2f9e181397872c7ee6415b7b95156d711b7eab6c55f66e575bc/boto3-1.43.0.tar.gz", hash = "sha256:80d44a943ef90aba7958ab31d30c155c198acc8a9581b5846b3878b2c8951086", size = 113143, upload-time = "2026-04-29T22:07:49.084Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/bd/a0c5011a8eddce39a9b613b13a75057bf960ef2145ff4d1583ed81a2599b/boto3-1.42.90-py3-none-any.whl", hash = "sha256:fde7f7bcad6ec8342d6bf18f56d118d0cb6df189310cfaf73e2eb6443b1cb418", size = 140554, upload-time = "2026-04-16T20:27:40.226Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a0/3e6a0b1c1ea6bec76f71473727ef27abf3cd40e9709b3ebcbfbcfaae6f79/boto3-1.43.0-py3-none-any.whl", hash = "sha256:8ebe03754a4b73a5cb6ec2f14cca03ac33bd4760d0adea53da4724845130258b", size = 140497, upload-time = "2026-04-29T22:07:46.216Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.97"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/95/c37edb602948fad2253ffd1bb3dba5b938645bd1845ee4160350136a0f41/botocore-1.42.97.tar.gz", hash = "sha256:5c0bb00e32d16ff6d278cc8c9e10dc3672d9c1d569031635ac3c908a60de8310", size = 15269348, upload-time = "2026-04-27T20:39:05.625Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/79/2f4be1896db3db7ccf44504253a175d56b6bd6b669619edc5147d1aa21ea/botocore-1.43.0.tar.gz", hash = "sha256:e933b31a2d644253e1d029d7d39e99ba41b87e29300534f189744cc438cdf928", size = 15286817, upload-time = "2026-04-29T22:07:31.723Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/d2/8e025ba1a4e257879af72d06913272311af79673d82fa2581a351b924317/botocore-1.42.97-py3-none-any.whl", hash = "sha256:77d2c8ce1bc592d3fbd7c01c35836f4a5b0cac2ca03ccdf6ffc60faa16b5fadc", size = 14950367, upload-time = "2026-04-27T20:39:01.261Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4b/afc1fef8a43bafb139f57f73bbd70df82807af5934321e8112ae50668827/botocore-1.43.0-py3-none-any.whl", hash = "sha256:cc5b15eaec3c6eac05d8012cb5ef17ebe891beb88a16ca13c374bfaece1241e6", size = 14970102, upload-time = "2026-04-29T22:07:27Z" },
 ]
 
 [[package]]
@@ -1133,7 +1133,7 @@ requires-dist = [
     { name = "aiobotocore", specifier = ">=3.7.0" },
     { name = "awswrangler", specifier = ">=3.11.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.8.6" },
-    { name = "boto3", specifier = "==1.42.90" },
+    { name = "boto3", specifier = "==1.43.0" },
     { name = "croniter", specifier = ">=6.0.0" },
     { name = "data-linter", specifier = ">=6.3.6" },
     { name = "dataengineeringutils3", specifier = ">=1.4.3" },
@@ -1638,14 +1638,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.16.1"
+version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/29/af14f4ef3c11a50435308660e2cc68761c9a7742475e0585cd4396b91777/s3transfer-0.16.1.tar.gz", hash = "sha256:8e424355754b9ccb32467bdc568edf55be82692ef2002d934b1311dbb3b9e524", size = 154801, upload-time = "2026-04-22T20:36:06.475Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/b3/bcdc2f58fa92592db511beda154c2c08d28f21f6c4637f06a42a24b10c21/s3transfer-0.17.1.tar.gz", hash = "sha256:042dd5e3b1b512355e35a23f0223e426b7042e80b97830ea2680ddce327fc45e", size = 159439, upload-time = "2026-05-26T19:45:01.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/19/90d7d4ed51932c022d53f1d02d564b62d10e272692a1f9b76425c1ad2a02/s3transfer-0.16.1-py3-none-any.whl", hash = "sha256:61bcd00ccb83b21a0fe7e91a553fff9729d46c83b4e0106e7c314a733891f7c2", size = 86825, upload-time = "2026-04-22T20:36:04.992Z" },
+    { url = "https://files.pythonhosted.org/packages/85/dd/904873250a6554fbae40cddbf9198e3cc37a2f1319d5e1a5ce82fe269c17/s3transfer-0.17.1-py3-none-any.whl", hash = "sha256:5b9827d1044159bbb01b86ef8902760ea39281927f5de31de75e1d657177bf4c", size = 88264, upload-time = "2026-05-26T19:45:00.452Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
OPG digital are now sending Sirius files with the DB schema prefixing the table name. This change complements this PR in airflow-opg-etl: https://github.com/moj-analytical-services/airflow-opg-etl/pull/554

table_name may now be passed in with a hyphen, this change removes it and any prefix, if present. This means that the pipeline can correctly read the incoming files on their new path, but they are output without the prefix to ensure consistency with existing Athena tables.

Fixed a load of Ruff issues as the workflow pulls the latest ruff config and it flagged them suddenly